### PR TITLE
Potential fix for code scanning alert no. 1332: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dev-environment.yml
+++ b/.github/workflows/dev-environment.yml
@@ -19,6 +19,8 @@ env:
 
 jobs:
   devcontainer:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     env:
       CHEF_LICENSE: accept-no-persist


### PR DESCRIPTION
Potential fix for [https://github.com/sommerfeld-io/container-images/security/code-scanning/1332](https://github.com/sommerfeld-io/container-images/security/code-scanning/1332)

To fix the problem, add an explicit `permissions` block—preferably with the minimal required privileges—to the `devcontainer` job. Since the job appears only to check out code, run hadolint, and build a Docker image (and does not push or interact with pull requests or issues), `contents: read` should suffice. This should be added immediately under the job name (`devcontainer:`) and before `runs-on:` on line 22. No other code or imports are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
