### PR TITLE
ci(sbom): implement SBOM verification action and integrate into workflows

### DIFF
--- a/.folderslintrc
+++ b/.folderslintrc
@@ -5,6 +5,7 @@
 		".devcontainer",
 
 		".github",
+		".github/actions/*",
 		".github/prompts",
 		".github/skills/*",
 		".github/workflows",

--- a/.github/actions/verify-sbom/action.yml
+++ b/.github/actions/verify-sbom/action.yml
@@ -1,0 +1,110 @@
+---
+name: 'Verify BuildKit SBOM attestation'
+description: >
+  Fails if the SBOM attestation for a (multi-platform) image is missing, not valid SPDX, has an
+  implausibly low package count, or is not linked to the image's actual manifest digest. On
+  success, writes the extracted SPDX JSON for each platform to disk and exposes their paths.
+
+inputs:
+  image-ref:
+    description: 'Fully qualified image reference including tag, e.g. docker.io/sommerfeldio/ftp-client:abc123'
+    required: true
+  platforms:
+    description: 'Comma-separated platforms to verify'
+    required: false
+    default: 'linux/amd64,linux/arm64'
+  min-packages:
+    description: 'Minimum plausible SPDX package count per platform'
+    required: false
+    default: '5'
+
+outputs:
+  amd64-sbom-file:
+    description: 'Path to the extracted linux/amd64 SPDX JSON'
+    value: ${{ steps.verify.outputs.amd64-file }}
+  arm64-sbom-file:
+    description: 'Path to the extracted linux/arm64 SPDX JSON'
+    value: ${{ steps.verify.outputs.arm64-file }}
+
+runs:
+  using: composite
+  steps:
+    - id: verify
+      shell: bash
+      env:
+        IMAGE_REF: ${{ inputs.image-ref }}
+        PLATFORMS: ${{ inputs.platforms }}
+        MIN_PACKAGES: ${{ inputs.min-packages }}
+      run: |
+        set -euo pipefail
+
+        echo "[INFO] Verifying SBOM attestation(s) for $IMAGE_REF"
+
+        INSPECT_JSON="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .}}')"
+        RAW_INDEX="$(docker buildx imagetools inspect "$IMAGE_REF" --raw)"
+
+        FAIL=0
+        IFS=',' read -ra PLATFORM_LIST <<< "$PLATFORMS"
+
+        for PLATFORM in "${PLATFORM_LIST[@]}"; do
+          ARCH="${PLATFORM#linux/}"
+          echo "::group::Verifying SBOM for $PLATFORM"
+
+          # (a) Find the *real* image manifest digest for this platform (exclude attestation manifests).
+          IMAGE_DIGEST="$(jq -r --arg arch "$ARCH" '
+            .manifests[]
+            | select(.platform.architecture == $arch and .platform.os == "linux")
+            | select((.annotations["vnd.docker.reference.type"] // "") != "attestation-manifest")
+            | .digest' <<<"$RAW_INDEX" | head -n1)"
+
+          if [ -z "$IMAGE_DIGEST" ] || [ "$IMAGE_DIGEST" = "null" ]; then
+            echo "::error::No image manifest found for $PLATFORM in $IMAGE_REF"
+            FAIL=1; echo "::endgroup::"; continue
+          fi
+          echo "[INFO] $PLATFORM manifest digest = $IMAGE_DIGEST"
+
+          # (b) Find the attestation manifest that references that exact digest.
+          ATTESTATION_DIGEST="$(jq -r --arg d "$IMAGE_DIGEST" '
+            .manifests[]
+            | select(.annotations["vnd.docker.reference.type"] == "attestation-manifest")
+            | select(.annotations["vnd.docker.reference.digest"] == $d)
+            | .digest' <<<"$RAW_INDEX" | head -n1)"
+
+          if [ -z "$ATTESTATION_DIGEST" ] || [ "$ATTESTATION_DIGEST" = "null" ]; then
+            echo "::error::No attestation manifest references digest $IMAGE_DIGEST for $PLATFORM - image was pushed/retagged without attestations"
+            FAIL=1; echo "::endgroup::"; continue
+          fi
+          echo "[INFO] Attestation manifest $ATTESTATION_DIGEST correctly references image digest $IMAGE_DIGEST"
+
+          # (c) Extract the resolved SPDX document for this platform.
+          SBOM_FILE="sbom-${ARCH}.spdx.json"
+          jq -e --arg p "$PLATFORM" '.SBOM[$p].SPDX // empty' <<<"$INSPECT_JSON" > "$SBOM_FILE" || true
+
+          if [ ! -s "$SBOM_FILE" ]; then
+            echo "::error::Could not extract SPDX JSON for $PLATFORM via 'imagetools inspect --format {{json .SBOM}}'"
+            echo "[DEBUG] Raw .SBOM field was:"
+            jq '.SBOM' <<<"$INSPECT_JSON" | head -c 500
+            FAIL=1; echo "::endgroup::"; continue
+          fi
+
+          # (d) Validate it is well-formed SPDX with a plausible package count.
+          if ! jq -e 'has("spdxVersion") and has("packages")' "$SBOM_FILE" >/dev/null 2>&1; then
+            echo "::error::$SBOM_FILE for $PLATFORM is missing spdxVersion/packages - not a valid SPDX document"
+            FAIL=1; echo "::endgroup::"; continue
+          fi
+
+          PKG_COUNT="$(jq '.packages | length' "$SBOM_FILE")"
+          echo "[INFO] $PLATFORM SPDX package count = $PKG_COUNT"
+          if [ "$PKG_COUNT" -lt "$MIN_PACKAGES" ]; then
+            echo "::error::$PLATFORM SBOM has only $PKG_COUNT packages (< $MIN_PACKAGES) - looks like a broken/empty scan"
+            FAIL=1; echo "::endgroup::"; continue
+          fi
+
+          echo "${ARCH}-file=${SBOM_FILE}" >> "$GITHUB_OUTPUT"
+          echo "::endgroup::"
+        done
+
+        if [ "$FAIL" -ne 0 ]; then
+          echo "::error::SBOM attestation verification failed for $IMAGE_REF"
+          exit 1
+        fi

--- a/.github/actions/verify-sbom/action.yml
+++ b/.github/actions/verify-sbom/action.yml
@@ -40,7 +40,9 @@ runs:
 
         echo "[INFO] Verifying SBOM attestation(s) for $IMAGE_REF"
 
-        INSPECT_JSON="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .}}')"
+        # NOTE: the SBOM attestation is a computed field, not part of the struct returned by
+        # '{{json .}}' - it must be requested explicitly via '{{json .SBOM}}'.
+        SBOM_JSON="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .SBOM}}')"
         RAW_INDEX="$(docker buildx imagetools inspect "$IMAGE_REF" --raw)"
 
         FAIL=0
@@ -78,12 +80,12 @@ runs:
 
           # (c) Extract the resolved SPDX document for this platform.
           SBOM_FILE="sbom-${ARCH}.spdx.json"
-          jq -e --arg p "$PLATFORM" '.SBOM[$p].SPDX // empty' <<<"$INSPECT_JSON" > "$SBOM_FILE" || true
+          jq -e --arg p "$PLATFORM" '.[$p].SPDX // empty' <<<"$SBOM_JSON" > "$SBOM_FILE" || true
 
           if [ ! -s "$SBOM_FILE" ]; then
             echo "::error::Could not extract SPDX JSON for $PLATFORM via 'imagetools inspect --format {{json .SBOM}}'"
             echo "[DEBUG] Raw .SBOM field was:"
-            jq '.SBOM' <<<"$INSPECT_JSON" | head -c 500
+            echo "$SBOM_JSON" | head -c 500
             FAIL=1; echo "::endgroup::"; continue
           fi
 

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -227,6 +227,10 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true
           sbom: true
+      - name: Verify SBOM attestation was generated for the pushed image
+        uses: ./.github/actions/verify-sbom
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ secrets.DOCKERHUB_USER }}/${{ matrix.image-name }}:${{ github.sha }}${{ matrix.tag-suffix }}
 
   inspec-images:
     runs-on: ubuntu-latest
@@ -347,6 +351,10 @@ jobs:
             dockerfile-stage: pdf
             tag-suffix: -pdf
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: true
       - name: Login to Container Registry
         uses: docker/login-action@v4
         with:
@@ -367,6 +375,10 @@ jobs:
           TARGET_IMAGE="$DOCKERHUB_USER/$IMAGE_NAME:$IMAGE_TAG_EDGE$TAG_SUFFIX"
           docker buildx imagetools create --tag "$TARGET_IMAGE" "$SRC_IMAGE"
         shell: bash
+      - name: Verify SBOM attestation survived the retag to :${{ env.IMAGE_TAG_EDGE }}
+        uses: ./.github/actions/verify-sbom
+        with:
+          image-ref: ${{ secrets.DOCKERHUB_USER }}/${{ matrix.image-name }}:${{ env.IMAGE_TAG_EDGE }}${{ matrix.tag-suffix }}
 
   # ----- Build Docs stage ------------------------------------------------------------------------
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -180,6 +180,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
       - name: Deploy to DockerHub
+        id: deploy
         env:
           DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
           IMAGE_NAME: ${{ matrix.image-name }}
@@ -190,6 +191,7 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           TAG="${TAG#v}"
           echo "[INFO] New version tag = $TAG"
+          echo "version=$TAG" >> "$GITHUB_OUTPUT"
 
           SRC_IMAGE="$DOCKERHUB_USER/$IMAGE_NAME:$IMAGE_TAG_EDGE$TAG_SUFFIX"
 
@@ -199,6 +201,14 @@ jobs:
           TARGET_IMAGE="$DOCKERHUB_USER/$IMAGE_NAME:$IMAGE_TAG_LATEST$TAG_SUFFIX"
           docker buildx imagetools create --tag "$TARGET_IMAGE" "$SRC_IMAGE"
         shell: bash
+      - name: Verify SBOM attestation survived retag to version tag
+        uses: ./.github/actions/verify-sbom
+        with:
+          image-ref: ${{ secrets.DOCKERHUB_USER }}/${{ matrix.image-name }}:${{ steps.deploy.outputs.version }}${{ matrix.tag-suffix }}
+      - name: Verify SBOM attestation survived retag to :${{ env.IMAGE_TAG_LATEST }}
+        uses: ./.github/actions/verify-sbom
+        with:
+          image-ref: ${{ secrets.DOCKERHUB_USER }}/${{ matrix.image-name }}:${{ env.IMAGE_TAG_LATEST }}${{ matrix.tag-suffix }}
       - name: Update DockerHub description
         if: ${{ matrix.tag-suffix == '' }}
         uses: peter-evans/dockerhub-description@v5
@@ -233,26 +243,54 @@ jobs:
             dockerfile-stage: pdf
             tag-suffix: -pdf
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          submodules: true
       - name: Login to Container Registry
         uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Extract version from release tag
         id: release
         run: |
           TAG="${{ github.event.release.tag_name }}"
           echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
         shell: bash
-      - name: Generate SPDX SBOM from Docker image
-        uses: anchore/sbom-action@v0
+      - name: Verify and extract the exact SBOM attestation from the published image
+        id: sbom
+        uses: ./.github/actions/verify-sbom
         with:
-          image: ${{ env.REGISTRY }}/${{ secrets.DOCKERHUB_USER }}/${{ matrix.image-name }}:${{ steps.release.outputs.version }}${{ matrix.tag-suffix }}
-          format: spdx-json
-          output-file: ${{ secrets.DOCKERHUB_USER }}-${{ matrix.image-name }}${{ matrix.tag-suffix }}_${{ steps.release.outputs.version }}.spdx.json
-          upload-release-assets: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          image-ref: ${{ env.REGISTRY }}/${{ secrets.DOCKERHUB_USER }}/${{ matrix.image-name }}:${{ steps.release.outputs.version }}${{ matrix.tag-suffix }}
+      - name: Rename SBOM files for release asset naming
+        id: rename
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          IMAGE_NAME: ${{ matrix.image-name }}
+          TAG_SUFFIX: ${{ matrix.tag-suffix }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+          AMD64_DEST="${DOCKERHUB_USER}-${IMAGE_NAME}${TAG_SUFFIX}_${VERSION}.spdx.json"
+          ARM64_DEST="${DOCKERHUB_USER}-${IMAGE_NAME}${TAG_SUFFIX}_${VERSION}.linux-arm64.spdx.json"
+          mv "${{ steps.sbom.outputs.amd64-sbom-file }}" "$AMD64_DEST"
+          mv "${{ steps.sbom.outputs.arm64-sbom-file }}" "$ARM64_DEST"
+          echo "amd64_dest=$AMD64_DEST" >> "$GITHUB_OUTPUT"
+          echo "arm64_dest=$ARM64_DEST" >> "$GITHUB_OUTPUT"
+        shell: bash
+      - name: Upload SBOMs as GitHub Release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            "${{ steps.rename.outputs.amd64_dest }}" \
+            "${{ steps.rename.outputs.arm64_dest }}" \
+            --clobber
+        shell: bash
 
   docker-scout:
     name: ${{ matrix.image-name }}${{ matrix.tag-suffix }}

--- a/components/devcontainer/README.md
+++ b/components/devcontainer/README.md
@@ -11,7 +11,9 @@ The `sommerfeldio/devcontainer` Docker image serves as a foundational developmen
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags. Retrieve it with `docker scout sbom sommerfeldio/devcontainer:latest` or `docker buildx imagetools inspect sommerfeldio/devcontainer:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/components/devcontainer/README.md
+++ b/components/devcontainer/README.md
@@ -13,7 +13,12 @@ Learn about our tagging policy and the difference between rolling tags and immut
 
 ### Software Bill of Materials (SBOM)
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags. Retrieve it with `docker scout sbom sommerfeldio/devcontainer:latest` or `docker buildx imagetools inspect sommerfeldio/devcontainer:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/devcontainer:latest` or
+- `docker buildx imagetools inspect sommerfeldio/devcontainer:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/components/folderslint/README.md
+++ b/components/folderslint/README.md
@@ -13,7 +13,12 @@ Learn about our tagging policy and the difference between rolling tags and immut
 
 ### Software Bill of Materials (SBOM)
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags. Retrieve it with `docker scout sbom sommerfeldio/folderslint:latest` or `docker buildx imagetools inspect sommerfeldio/folderslint:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/folderslint:latest` or
+- `docker buildx imagetools inspect sommerfeldio/folderslint:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/components/folderslint/README.md
+++ b/components/folderslint/README.md
@@ -11,7 +11,9 @@ The `sommerfeldio/folderslint` image is a utility Docker image used in Github Ac
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags. Retrieve it with `docker scout sbom sommerfeldio/folderslint:latest` or `docker buildx imagetools inspect sommerfeldio/folderslint:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/components/ftp-client/README.md
+++ b/components/ftp-client/README.md
@@ -13,7 +13,12 @@ Learn about our tagging policy and the difference between rolling tags and immut
 
 ### Software Bill of Materials (SBOM)
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags. Retrieve it with `docker scout sbom sommerfeldio/ftp-client:latest` or `docker buildx imagetools inspect sommerfeldio/ftp-client:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/ftp-client:latest` or
+- `docker buildx imagetools inspect sommerfeldio/ftp-client:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## How to use this image
 

--- a/components/ftp-client/README.md
+++ b/components/ftp-client/README.md
@@ -11,7 +11,9 @@ The `sommerfeldio/ftp-client` image ships with NCFTP and uses [ncftpput](https:/
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags. Retrieve it with `docker scout sbom sommerfeldio/ftp-client:latest` or `docker buildx imagetools inspect sommerfeldio/ftp-client:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## How to use this image
 

--- a/components/mkdocs/README.md
+++ b/components/mkdocs/README.md
@@ -15,7 +15,9 @@ The image focuses on generating the documentation site (e.g. from a pipeline). I
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags. Retrieve it with `docker scout sbom sommerfeldio/mkdocs:latest` or `docker buildx imagetools inspect sommerfeldio/mkdocs:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/components/mkdocs/README.md
+++ b/components/mkdocs/README.md
@@ -17,7 +17,12 @@ Learn about our tagging policy and the difference between rolling tags and immut
 
 ### Software Bill of Materials (SBOM)
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags. Retrieve it with `docker scout sbom sommerfeldio/mkdocs:latest` or `docker buildx imagetools inspect sommerfeldio/mkdocs:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/mkdocs:latest` or
+- `docker buildx imagetools inspect sommerfeldio/mkdocs:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/components/revealjs/README.md
+++ b/components/revealjs/README.md
@@ -11,7 +11,9 @@ The `sommerfeldio/revealjs` image is a utility Docker image used to render [Reve
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags of both `sommerfeldio/revealjs` and `sommerfeldio/revealjs-pdf`. Retrieve it with `docker scout sbom sommerfeldio/revealjs:latest` or `docker buildx imagetools inspect sommerfeldio/revealjs:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/components/revealjs/README.md
+++ b/components/revealjs/README.md
@@ -13,7 +13,12 @@ Learn about our tagging policy and the difference between rolling tags and immut
 
 ### Software Bill of Materials (SBOM)
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `sha`, `edge`, `latest` and versioned tags of both `sommerfeldio/revealjs` and `sommerfeldio/revealjs-pdf`. Retrieve it with `docker scout sbom sommerfeldio/revealjs:latest` or `docker buildx imagetools inspect sommerfeldio/revealjs:latest --format "{{ json .SBOM }}"`. The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/revealjs:latest` or
+- `docker buildx imagetools inspect sommerfeldio/revealjs:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/docs/container-images/devcontainer.md
+++ b/docs/container-images/devcontainer.md
@@ -11,7 +11,14 @@ The `sommerfeldio/devcontainer` Docker image serves as a foundational developmen
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/devcontainer:latest` or
+- `docker buildx imagetools inspect sommerfeldio/devcontainer:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/docs/container-images/folderslint.md
+++ b/docs/container-images/folderslint.md
@@ -11,7 +11,14 @@ The `sommerfeldio/folderslint` image is a utility Docker image used in Github Ac
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/folderslint:latest` or
+- `docker buildx imagetools inspect sommerfeldio/folderslint:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/docs/container-images/ftp-client.md
+++ b/docs/container-images/ftp-client.md
@@ -11,7 +11,14 @@ The `sommerfeldio/ftp-client` image ships with NCFTP and uses [ncftpput](https:/
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/ftp-client:latest` or
+- `docker buildx imagetools inspect sommerfeldio/ftp-client:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## How to use this image
 

--- a/docs/container-images/mkdocs.md
+++ b/docs/container-images/mkdocs.md
@@ -15,7 +15,14 @@ The image focuses on generating the documentation site (e.g. from a pipeline). I
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/mkdocs:latest` or
+- `docker buildx imagetools inspect sommerfeldio/mkdocs:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 

--- a/docs/container-images/revealjs.md
+++ b/docs/container-images/revealjs.md
@@ -11,7 +11,14 @@ The `sommerfeldio/revealjs` image is a utility Docker image used to render [Reve
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-Starting with version 0.22.0, a Software Bill of Materials (SBOM) in SPDX format is generated for every image and attached to each [GitHub release](https://github.com/sommerfeld-io/container-images/releases) as a downloadable asset.
+### Software Bill of Materials (SBOM)
+
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/revealjs:latest` or
+- `docker buildx imagetools inspect sommerfeldio/revealjs:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
 ## Usage
 


### PR DESCRIPTION
Ensure Software Bill of Materials (SBOM) attestations are generated at build time and survive retagging operations across all image tags in Docker Hub.

This PR adds a new GitHub Action that validates SBOM attestations are present, well-formed, and correctly linked to image manifests. The action is integrated into the build, edge retag, and release workflows to prevent images from being pushed or retagged without their attestations. The action also extracts the SPDX JSON for each platform and exposes it for downstream use—particularly important in the release workflow where SBOMs are attached as GitHub release assets. Documentation updates clarify that SBOMs are now available as OCI attestations on all tags via `docker scout sbom` or `docker buildx imagetools inspect`.

### Changes

- Add `verify-sbom` GitHub Action that validates SBOM attestations for a given image reference
  - Verifies attestation manifest is present and correctly references the image digest
  - Validates SPDX document structure and enforces a minimum package count
  - Extracts SPDX JSON to disk for integration with downstream workflows
- Integrate SBOM verification into the pipeline workflow after the image build/push step
- Integrate SBOM verification into the edge retag and release retag workflows to ensure attestations survive retagging
- Update release workflow to use the verified attestations as GitHub release assets instead of generating SBOMs on-the-fly
- Update component README files to document SBOM availability and retrieval methods
- Update folder lint configuration to allow the new `.github/actions` directory structure

### Benefits

- Guarantees all pushed images have valid SBOM attestations; broken builds fail fast
- Ensures attestations persist through retag operations; no orphaned images without metadata
- Integrates SBOM extraction directly into CI, reducing runtime overhead in the release step
- Provides transparent, auditable access to SBOM data via OCI attestations rather than separate asset files