### PR TITLE
fix(ci): avoid unauthenticated DockerHub rate limit in verify-sbom

### DIFF
--- a/.github/actions/verify-sbom/action.yml
+++ b/.github/actions/verify-sbom/action.yml
@@ -40,10 +40,27 @@ runs:
 
         echo "[INFO] Verifying SBOM attestation(s) for $IMAGE_REF"
 
-        # NOTE: the SBOM attestation is a computed field, not part of the struct returned by
-        # '{{json .}}' - it must be requested explicitly via '{{json .SBOM}}'.
-        SBOM_JSON="$(docker buildx imagetools inspect "$IMAGE_REF" --format '{{json .SBOM}}')"
-        RAW_INDEX="$(docker buildx imagetools inspect "$IMAGE_REF" --raw)"
+        # Use the "default" builder (backed by the local Docker Engine) rather than whatever
+        # docker-container builder the workflow may have created with setup-buildx-action. The
+        # docker-container driver runs BuildKit in its own container, which does not inherit the
+        # credentials from a preceding `docker login` - imagetools then resolves attestation
+        # blobs as an anonymous user and quickly hits DockerHub's unauthenticated rate limit.
+        # The "default" builder talks to the local Docker Engine directly, which does share
+        # ~/.docker/config.json, so authenticated requests are used instead.
+        inspect_with_retry() {
+          local attempt
+          for attempt in 1 2 3; do
+            if docker buildx imagetools inspect --builder default "$IMAGE_REF" "$@"; then
+              return 0
+            fi
+            echo "[WARN] imagetools inspect attempt $attempt/3 failed, retrying in $((attempt * 10))s..." >&2
+            sleep "$((attempt * 10))"
+          done
+          return 1
+        }
+
+        SBOM_JSON="$(inspect_with_retry --format '{{json .SBOM}}')"
+        RAW_INDEX="$(inspect_with_retry --raw)"
 
         FAIL=0
         IFS=',' read -ra PLATFORM_LIST <<< "$PLATFORMS"


### PR DESCRIPTION
Fixes the release pipeline's SBOM verification step failing with a DockerHub "unauthenticated pull rate limit" error, even though the job had already logged in with valid credentials.

The verify-sbom action needs to resolve each image's `.SBOM` attestation, which requires fetching attestation-manifest blobs from the registry. That lookup runs through whichever buildx builder is currently active. Since the release workflow creates a `docker-container` builder via `setup-buildx-action` to support multi-platform builds, and that builder runs BuildKit inside its own isolated container, it doesn't inherit the host's DockerHub login credentials — so the lookup goes out as an anonymous request and quickly exhausts DockerHub's much stricter unauthenticated quota, even though the exact same job successfully authenticated moments earlier for the actual image push/retag.

### Changes

- This PR pins the SBOM/manifest lookups in `verify-sbom` to the `default` buildx builder, which is backed directly by the local Docker Engine and does share the credentials written by `docker login`.
- This PR wraps the lookup in a short retry with backoff, since DockerHub rate limits can still be hit transiently even when authenticated, especially across a matrix of several images verified in the same run.

### Benefits

- The release workflow no longer fails intermittently on SBOM verification for reasons unrelated to the actual attestation data.
- Verification requests are now authenticated, which raises the effective rate-limit ceiling substantially.
- Transient rate-limit blips are absorbed automatically instead of failing the whole release run.