### PR TITLE
feat(zensical): add zensical as the docs-site builder and mkdocs successor

### DIFF
--- a/.folderslintrc
+++ b/.folderslintrc
@@ -25,6 +25,7 @@
 		"components/ftp-client/configs/etc",
 		"components/mkdocs",
 		"components/revealjs/demo/slides",
+		"components/zensical",
         "components/*/test/inspec/**",
 
 		"docs",

--- a/.folderslintrc
+++ b/.folderslintrc
@@ -7,7 +7,6 @@
 		".github",
 		".github/actions/*",
 		".github/prompts",
-		".github/skills/*",
 		".github/workflows",
 		".github/workflows/assets",
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,8 +57,8 @@ task test:revealjs
 
 # generate and preview docs
 task docs:generate
-task docs:zensical:run
-docker compose up zensical-docs-build
+task docs:run
+docker compose up docs-build
 ```
 
 ## High-level architecture

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -57,8 +57,8 @@ task test:revealjs
 
 # generate and preview docs
 task docs:generate
-task docs:run
-docker compose up docs-build
+task docs:zensical:run
+docker compose up mkdocs-docs-build
 ```
 
 ## High-level architecture

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -58,7 +58,7 @@ task test:revealjs
 # generate and preview docs
 task docs:generate
 task docs:zensical:run
-docker compose up mkdocs-docs-build
+docker compose up zensical-docs-build
 ```
 
 ## High-level architecture

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -412,8 +412,8 @@ jobs:
       - name: Run task to generate docs
         run: task docs:generate
         shell: bash
-      - name: Build mkdocs-docs-build image
-        run: docker compose build mkdocs-docs-build
+      - name: zensical-docs-build
+        run: docker compose build zensical-docs-build
         shell: bash
       - name: Commit and push
         uses: EndBug/add-and-commit@v11.1.1

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -124,7 +124,7 @@ jobs:
     name: ${{ matrix.image-name }}
     strategy:
       matrix:
-        image-name: ['devcontainer', 'folderslint', 'ftp-client', 'mkdocs', 'revealjs']
+        image-name: ['devcontainer', 'folderslint', 'ftp-client', 'mkdocs', 'revealjs', 'zensical']
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -174,6 +174,8 @@ jobs:
           - image-name: revealjs
             dockerfile-stage: pdf
             tag-suffix: -pdf
+          - image-name: zensical
+            tag-suffix: ''
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -305,6 +307,8 @@ jobs:
           - image-name: revealjs
             dockerfile-stage: pdf
             tag-suffix: -pdf
+          - image-name: zensical
+            tag-suffix: ''
     steps:
       - name: Login to Container Registry
         uses: docker/login-action@v4.6.0
@@ -352,6 +356,8 @@ jobs:
           - image-name: revealjs
             dockerfile-stage: pdf
             tag-suffix: -pdf
+          - image-name: zensical
+            tag-suffix: ''
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -406,8 +412,8 @@ jobs:
       - name: Run task to generate docs
         run: task docs:generate
         shell: bash
-      - name: Build docs-build image
-        run: docker compose build docs-build
+      - name: Build mkdocs-docs-build image
+        run: docker compose build mkdocs-docs-build
         shell: bash
       - name: Commit and push
         uses: EndBug/add-and-commit@v11.1.1
@@ -455,6 +461,8 @@ jobs:
           - image-name: revealjs
             dockerfile-stage: pdf
             tag-suffix: -pdf
+          - image-name: zensical
+            tag-suffix: ''
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -412,8 +412,8 @@ jobs:
       - name: Run task to generate docs
         run: task docs:generate
         shell: bash
-      - name: zensical-docs-build
-        run: docker compose build zensical-docs-build
+      - name: docs-build
+        run: docker compose build docs-build
         shell: bash
       - name: Commit and push
         uses: EndBug/add-and-commit@v11.1.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: true
           ref: ${{github.ref}}
       - name: Build docs page
-        run: docker compose up docs-build
+        run: docker compose up mkdocs-docs-build
         shell: bash
       - name: List contents
         run: ls -alF target/docs/site
@@ -88,6 +88,8 @@ jobs:
           - image-name: revealjs
             dockerfile-stage: pdf
             tag-suffix: -pdf
+          - image-name: zensical
+            tag-suffix: ''
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -164,6 +166,8 @@ jobs:
           - image-name: revealjs
             dockerfile-stage: pdf
             tag-suffix: -pdf
+          - image-name: zensical
+            tag-suffix: ''
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -238,6 +242,8 @@ jobs:
           - image-name: revealjs
             dockerfile-stage: pdf
             tag-suffix: -pdf
+          - image-name: zensical
+            tag-suffix: ''
     steps:
       # - name: Checkout code
       #   uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: true
           ref: ${{github.ref}}
       - name: Build docs page
-        run: docker compose up zensical-docs-build
+        run: docker compose up docs-build
         shell: bash
       - name: List contents
         run: ls -alF target/docs/site

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           submodules: true
           ref: ${{github.ref}}
       - name: Build docs page
-        run: docker compose up mkdocs-docs-build
+        run: docker compose up zensical-docs-build
         shell: bash
       - name: List contents
         run: ls -alF target/docs/site

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule ".github/skills"]
-	path = .github/skills
-	url = git@github.com:sommerfeld-io/skills.git
 [submodule ".vscode"]
 	path = .vscode
 	url = git@github.com:sommerfeld-io/.vscode.git

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -54,8 +54,6 @@ ignore:
   - components/ftp-client/test/inspec/vendor
   - components/revealjs/test/inspec/vendor
 
-  - .github/skills/.markdownlint.yml
-
   # linter definitions etc.
   - .editorconfig
   - .hadolint.yml

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -9,7 +9,15 @@ exclude_path = [
 ]
 exclude_loopback = true
 exclude = [
-    '.*fritz\.box.*'
+    '.*fritz\.box.*',
+
+    # TODO: temporary bootstrap exclusions for the new zensical component - these
+    # links are correct but 404 until this branch is merged to main (GitHub blob/tree
+    # links resolve against main) and the image's first Docker Hub publish completes.
+    # Remove once both are live.
+    'github\.com/sommerfeld-io/container-images/blob/main/zensical\.toml',
+    'github\.com/sommerfeld-io/container-images/tree/main/components/zensical',
+    'hub\.docker\.com/r/sommerfeldio/zensical'
 ]
 
 format = 'detailed' # compact, detailed, json, markdown, raw

--- a/components/mkdocs/README.md
+++ b/components/mkdocs/README.md
@@ -1,4 +1,4 @@
-# sommerfeldio/mkdocs
+# sommerfeldio/mkdocs (DEPRECATED)
 
 This image is used to build the documentation using the `mkdocs` toolchain and is based on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
 

--- a/components/mkdocs/README.md
+++ b/components/mkdocs/README.md
@@ -1,35 +1,35 @@
 # sommerfeldio/mkdocs
 
-> **Deprecation Notice**: `sommerfeldio/mkdocs` is deprecated as of version `0.28.0`.
->
-> Starting with `0.28.0`, the `sommerfeldio/mkdocs` container image will **no longer be maintained**. This means:
->
-> - No new features
-> - No bug fixes
-> - No security updates
-> - No dependency upgrades
->
-> The image will remain available on GitHub, but it is **frozen** and should not be relied upon for anything going forward. `0.28.0` is the last version available Docker Hub.
->
-> **Why?**
->
-> `sommerfeldio/mkdocs` is built on [https://squidfunk.github.io/mkdocs-material](Material for MkDocs), which in turn depends on **MkDocs**. MkDocs has been unmaintained since August 2024, with no releases in over a year. As a result, Material for MkDocs itself has entered maintenance mode, and the team has [announced Zensical](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) as its successor - a next-generation static site generator that consolidates static site generation, theming, and customization into a single coherent stack, free of the MkDocs dependency.
->
-> **Recommended migration: `sommerfeldio/zensical`**
->
-> Switch to `sommerfeldio/zensical` as a drop-in replacement. Because Zensical guarantees compatibility with Material for MkDocs, migrating away from `sommerfeldio/mkdocs` should require little to no change to your documentation sources.
->
-> - Reads your existing `mkdocs.yml` natively, so you can build your current project with minimal changes.
-> - Leaves your Markdown files, template overrides, and CSS/JavaScript extensions untouched (the generated HTML is unchanged and content is still processed via Python Markdown).
-> Ships as fully Open Source (MIT-licensed).
->
-> Review the [Zensical compatibility page](https://zensical.org/compatibility/) before migrating if you rely on specific plugins.
->
-> **Learn more**
->
-> - Zensical announcement: <https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/>
-> - Zensical website: <https://zensical.org/>
-> - Zensical compatibility: <https://zensical.org/compatibility/>
+## Deprecation Notice: `sommerfeldio/mkdocs` is deprecated as of version `0.28.0`
+
+Starting with `0.28.0`, the `sommerfeldio/mkdocs` container image will **no longer be maintained**. This means:
+
+- No new features
+- No bug fixes
+- No security updates
+- No dependency upgrades
+
+The image will remain available on GitHub, but it is **frozen** and should not be relied upon for anything going forward. `0.28.0` is the last version available Docker Hub.
+
+### Why?
+
+`sommerfeldio/mkdocs` is built on [https://squidfunk.github.io/mkdocs-material](Material for MkDocs), which in turn depends on **MkDocs**. MkDocs has been unmaintained since August 2024, with no releases in over a year. As a result, Material for MkDocs itself has entered maintenance mode, and the team has [announced Zensical](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) as its successor - a next-generation static site generator that consolidates static site generation, theming, and customization into a single coherent stack, free of the MkDocs dependency.
+
+### Recommended migration: `sommerfeldio/zensical`
+
+Switch to `sommerfeldio/zensical` as a drop-in replacement. Because Zensical guarantees compatibility with Material for MkDocs, migrating away from `sommerfeldio/mkdocs` should require little to no change to your documentation sources.
+
+- Reads your existing `mkdocs.yml` natively, so you can build your current project with minimal changes.
+- Leaves your Markdown files, template overrides, and CSS/JavaScript extensions untouched (the generated HTML is unchanged and content is still processed via Python Markdown).
+- Ships as fully Open Source (MIT-licensed).
+
+Review the [Zensical compatibility page](https://zensical.org/compatibility/) before migrating if you rely on specific plugins.
+
+### Learn more
+
+- Zensical announcement: <https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/>
+- Zensical website: <https://zensical.org/>
+- Zensical compatibility: <https://zensical.org/compatibility/>
 
 This image is used to build the documentation using the `mkdocs` toolchain and is based on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
 
@@ -40,54 +40,56 @@ This image extends the [squidfunk/mkdocs-material](https://hub.docker.com/r/squi
 - [How to Contribute](https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md)
 - Visit [the projects documentation page](https://sommerfeld-io.github.io/container-images) for a list of all available container images.
 
-The image focuses on generating the documentation site (e.g. from a pipeline). It is not intended to be used as a live webserver for production.
-
-## Software Tags and Versioning
-
-Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
-
-### Software Bill of Materials (SBOM)
-
-Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
-
-- `docker scout sbom sommerfeldio/mkdocs:latest` or
-- `docker buildx imagetools inspect sommerfeldio/mkdocs:latest --format "{{ json .SBOM }}"`.
-
-The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
-
-## Usage
-
-This image supports two modes. The `build` command is used to build the documentation site based on your Markdown docs. The container terminates after the build is complete. Additionally the image offers a development server to preview the documentation site. Both features originate in the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) base image.
-
-The easiest way to use the image is to run it with Docker Compose:
-
-```yaml
-services:
-
-  docs-build:
-    container_name: docs-build
-    image: &docs-image sommerfeldio/mkdocs:latest
-    volumes: &volumes
-      - /etc/timezone:/etc/timezone:ro
-      - /etc/localtime:/etc/localtime:ro
-      - .:/workspaces/your-project
-    working_dir: &default-workdir /workspaces/your-project
-    command: build
-
-  docs-dev-server:
-    container_name: docs-dev-server
-    image: *docs-image
-    volumes: *volumes
-    working_dir: *default-workdir
-    ports:
-      - 3080:8000
-```
-
-The development server is not recommended for production use. It is intended to be used during the development of the documentation site. For production use, the `build` command should be used to generate the static site. This triggers the production-level compilation and minification of all style sheets and JavaScript files. The resulting static site can be served by a web server like [nginx](https://hub.docker.com/_/nginx) or [Apache httpd](https://hub.docker.com/_/httpd).
-
-For information on how to get started with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material), please refer to the [official "Getting started" guide of the projects documentation](https://squidfunk.github.io/mkdocs-material/getting-started).
-
-For information on how to configure the mkdocs-kroki-plugin, please refer to the [official documentation of the plugin](https://pypi.org/project/mkdocs-kroki-plugin).
+> ## About `sommerfeldio/mkdocs`
+>
+> The image focuses on generating the documentation site (e.g. from a pipeline). It is not intended to be used as a live webserver for production.
+>
+> ### Software Tags and Versioning
+>
+> Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
+>
+> #### Software Bill of Materials (SBOM)
+>
+> Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+>
+> - `docker scout sbom sommerfeldio/mkdocs:latest` or
+> - `docker buildx imagetools inspect sommerfeldio/mkdocs:latest --format "{{ json .SBOM }}"`.
+>
+> The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+>
+> ### Usage
+>
+> This image supports two modes. The `build` command is used to build the documentation site based on your Markdown docs. The container terminates after the build is complete. Additionally the image offers a development server to preview the documentation site. Both features originate in the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) base image.
+>
+> The easiest way to use the image is to run it with Docker Compose:
+>
+> ```yaml
+> services:
+>
+>   docs-build:
+>     container_name: docs-build
+>     image: &docs-image sommerfeldio/mkdocs:latest
+>     volumes: &volumes
+>       - /etc/timezone:/etc/timezone:ro
+>       - /etc/localtime:/etc/localtime:ro
+>       - .:/workspaces/your-project
+>     working_dir: &default-workdir /workspaces/your-project
+>     command: build
+>
+>   docs-dev-server:
+>     container_name: docs-dev-server
+>     image: *docs-image
+>     volumes: *volumes
+>     working_dir: *default-workdir
+>     ports:
+>       - 3080:8000
+> ```
+>
+> The development server is not recommended for production use. It is intended to be used during the development of the documentation site. For production use, the `build` command should be used to generate the static site. This triggers the production-level compilation and minification of all style sheets and JavaScript files. The resulting static site can be served by a web server like [nginx](https://hub.docker.com/_/nginx) or [Apache httpd](https://hub.docker.com/_/httpd).
+>
+> For information on how to get started with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material), please refer to the [official "Getting started" guide of the projects documentation](https://squidfunk.github.io/mkdocs-material/getting-started).
+>
+> For information on how to configure the mkdocs-kroki-plugin, please refer to the [official documentation of the plugin](https://pypi.org/project/mkdocs-kroki-plugin).
 
 ## License
 

--- a/components/mkdocs/README.md
+++ b/components/mkdocs/README.md
@@ -1,6 +1,13 @@
 # sommerfeldio/mkdocs
 
-## Deprecation Notice: `sommerfeldio/mkdocs` is deprecated as of version `0.28.0`
+This image is used to build the documentation using the `mkdocs` toolchain and is based on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
+
+- [sommerfeldio/mkdocs](https://hub.docker.com/r/sommerfeldio/mkdocs) on Docker Hub
+- [Dockerfile source code](https://github.com/sommerfeld-io/container-images/tree/main/components/mkdocs) on GitHub
+- [How to Contribute](https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md)
+- Visit [the projects documentation page](https://sommerfeld-io.github.io/container-images) for a list of all available container images.
+
+## DEPRECATION NOTICE: `sommerfeldio/mkdocs` is deprecated as of version `0.28.0`
 
 Starting with `0.28.0`, the `sommerfeldio/mkdocs` container image will **no longer be maintained**. This means:
 
@@ -9,7 +16,7 @@ Starting with `0.28.0`, the `sommerfeldio/mkdocs` container image will **no long
 - No security updates
 - No dependency upgrades
 
-The image will remain available on GitHub, but it is **frozen** and should not be relied upon for anything going forward. `0.28.0` is the last version available Docker Hub.
+The image will remain available on GitHub, but it is stale and should not be relied upon for anything going forward. `0.28.0` is the last version available Docker Hub.
 
 ### Why?
 
@@ -31,65 +38,58 @@ Review the [Zensical compatibility page](https://zensical.org/compatibility/) be
 - Zensical website: <https://zensical.org/>
 - Zensical compatibility: <https://zensical.org/compatibility/>
 
-This image is used to build the documentation using the `mkdocs` toolchain and is based on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
+## About the latest stable release which is `sommerfeldio/mkdocs:0.28.0`
 
 This image extends the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) image with the [mkdocs-kroki-plugin](https://pypi.org/project/mkdocs-kroki-plugin) to allow rendering diagrams and charts using [Kroki.io](https://kroki.io). A dedicated Dockerfile is needed because the base image does not provide all necessary plugins and tools.
 
-- [sommerfeldio/mkdocs](https://hub.docker.com/r/sommerfeldio/mkdocs) on Docker Hub
-- [Dockerfile source code](https://github.com/sommerfeld-io/container-images/tree/main/components/mkdocs) on GitHub
-- [How to Contribute](https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md)
-- Visit [the projects documentation page](https://sommerfeld-io.github.io/container-images) for a list of all available container images.
+The image focuses on generating the documentation site (e.g. from a pipeline). It is not intended to be used as a live webserver for production.
 
-> ## About `sommerfeldio/mkdocs`
->
-> The image focuses on generating the documentation site (e.g. from a pipeline). It is not intended to be used as a live webserver for production.
->
-> ### Software Tags and Versioning
->
-> Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
->
-> #### Software Bill of Materials (SBOM)
->
-> Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
->
-> - `docker scout sbom sommerfeldio/mkdocs:latest` or
-> - `docker buildx imagetools inspect sommerfeldio/mkdocs:latest --format "{{ json .SBOM }}"`.
->
-> The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
->
-> ### Usage
->
-> This image supports two modes. The `build` command is used to build the documentation site based on your Markdown docs. The container terminates after the build is complete. Additionally the image offers a development server to preview the documentation site. Both features originate in the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) base image.
->
-> The easiest way to use the image is to run it with Docker Compose:
->
-> ```yaml
-> services:
->
->   docs-build:
->     container_name: docs-build
->     image: &docs-image sommerfeldio/mkdocs:latest
->     volumes: &volumes
->       - /etc/timezone:/etc/timezone:ro
->       - /etc/localtime:/etc/localtime:ro
->       - .:/workspaces/your-project
->     working_dir: &default-workdir /workspaces/your-project
->     command: build
->
->   docs-dev-server:
->     container_name: docs-dev-server
->     image: *docs-image
->     volumes: *volumes
->     working_dir: *default-workdir
->     ports:
->       - 3080:8000
-> ```
->
-> The development server is not recommended for production use. It is intended to be used during the development of the documentation site. For production use, the `build` command should be used to generate the static site. This triggers the production-level compilation and minification of all style sheets and JavaScript files. The resulting static site can be served by a web server like [nginx](https://hub.docker.com/_/nginx) or [Apache httpd](https://hub.docker.com/_/httpd).
->
-> For information on how to get started with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material), please refer to the [official "Getting started" guide of the projects documentation](https://squidfunk.github.io/mkdocs-material/getting-started).
->
-> For information on how to configure the mkdocs-kroki-plugin, please refer to the [official documentation of the plugin](https://pypi.org/project/mkdocs-kroki-plugin).
+### Software Tags and Versioning
+
+Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
+
+#### Software Bill of Materials (SBOM)
+
+Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/mkdocs:latest` or
+- `docker buildx imagetools inspect sommerfeldio/mkdocs:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+
+### Usage
+
+This image supports two modes. The `build` command is used to build the documentation site based on your Markdown docs. The container terminates after the build is complete. Additionally the image offers a development server to preview the documentation site. Both features originate in the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) base image.
+
+The easiest way to use the image is to run it with Docker Compose:
+
+```yaml
+services:
+
+  docs-build:
+    container_name: docs-build
+    image: &docs-image sommerfeldio/mkdocs:latest
+    volumes: &volumes
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+      - .:/workspaces/your-project
+    working_dir: &default-workdir /workspaces/your-project
+    command: build
+
+  docs-dev-server:
+    container_name: docs-dev-server
+    image: *docs-image
+    volumes: *volumes
+    working_dir: *default-workdir
+    ports:
+      - 3080:8000
+```
+
+The development server is not recommended for production use. It is intended to be used during the development of the documentation site. For production use, the `build` command should be used to generate the static site. This triggers the production-level compilation and minification of all style sheets and JavaScript files. The resulting static site can be served by a web server like [nginx](https://hub.docker.com/_/nginx) or [Apache httpd](https://hub.docker.com/_/httpd).
+
+For information on how to get started with [Material for MkDocs](https://squidfunk.github.io/mkdocs-material), please refer to the [official "Getting started" guide of the projects documentation](https://squidfunk.github.io/mkdocs-material/getting-started).
+
+For information on how to configure the mkdocs-kroki-plugin, please refer to the [official documentation of the plugin](https://pypi.org/project/mkdocs-kroki-plugin).
 
 ## License
 

--- a/components/mkdocs/README.md
+++ b/components/mkdocs/README.md
@@ -1,5 +1,36 @@
 # sommerfeldio/mkdocs
 
+> **Deprecation Notice**: `sommerfeldio/mkdocs` is deprecated as of version `0.28.0`.
+>
+> Starting with `0.28.0`, the `sommerfeldio/mkdocs` container image will **no longer be maintained**. This means:
+>
+> - No new features
+> - No bug fixes
+> - No security updates
+> - No dependency upgrades
+>
+> The image will remain available on GitHub, but it is **frozen** and should not be relied upon for anything going forward. `0.28.0` is the last version available Docker Hub.
+>
+> **Why?**
+>
+> `sommerfeldio/mkdocs` is built on [https://squidfunk.github.io/mkdocs-material](Material for MkDocs), which in turn depends on **MkDocs**. MkDocs has been unmaintained since August 2024, with no releases in over a year. As a result, Material for MkDocs itself has entered maintenance mode, and the team has [announced Zensical](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) as its successor - a next-generation static site generator that consolidates static site generation, theming, and customization into a single coherent stack, free of the MkDocs dependency.
+>
+> **Recommended migration: `sommerfeldio/zensical`**
+>
+> Switch to `sommerfeldio/zensical` as a drop-in replacement. Because Zensical guarantees compatibility with Material for MkDocs, migrating away from `sommerfeldio/mkdocs` should require little to no change to your documentation sources.
+>
+> - Reads your existing `mkdocs.yml` natively, so you can build your current project with minimal changes.
+> - Leaves your Markdown files, template overrides, and CSS/JavaScript extensions untouched (the generated HTML is unchanged and content is still processed via Python Markdown).
+> Ships as fully Open Source (MIT-licensed).
+>
+> Review the [Zensical compatibility page](https://zensical.org/compatibility/) before migrating if you rely on specific plugins.
+>
+> **Learn more**
+>
+> - Zensical announcement: <https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/>
+> - Zensical website: <https://zensical.org/>
+> - Zensical compatibility: <https://zensical.org/compatibility/>
+
 This image is used to build the documentation using the `mkdocs` toolchain and is based on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
 
 This image extends the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) image with the [mkdocs-kroki-plugin](https://pypi.org/project/mkdocs-kroki-plugin) to allow rendering diagrams and charts using [Kroki.io](https://kroki.io). A dedicated Dockerfile is needed because the base image does not provide all necessary plugins and tools.

--- a/components/mkdocs/README.md
+++ b/components/mkdocs/README.md
@@ -1,6 +1,8 @@
-# sommerfeldio/mkdocs (DEPRECATED)
+# sommerfeldio/mkdocs
 
 This image is used to build the documentation using the `mkdocs` toolchain and is based on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
+
+![Deprecated](https://raw.githubusercontent.com/sommerfeld-io/container-images/refs/heads/main/.assets/deprecated.png)
 
 - [sommerfeldio/mkdocs](https://hub.docker.com/r/sommerfeldio/mkdocs) on Docker Hub
 - [Dockerfile source code](https://github.com/sommerfeld-io/container-images/tree/main/components/mkdocs) on GitHub

--- a/components/mkdocs/README.md
+++ b/components/mkdocs/README.md
@@ -16,11 +16,9 @@ Starting with `0.28.0`, the `sommerfeldio/mkdocs` container image will **no long
 - No security updates
 - No dependency upgrades
 
-The image will remain available on GitHub, but it is stale and should not be relied upon for anything going forward. `0.28.0` is the last version available Docker Hub.
+The image will remain available on GitHub, but it is stale and should not be relied upon for anything going forward. `0.28.0` is the last version available on Docker Hub.
 
-### Why?
-
-`sommerfeldio/mkdocs` is built on [https://squidfunk.github.io/mkdocs-material](Material for MkDocs), which in turn depends on **MkDocs**. MkDocs has been unmaintained since August 2024, with no releases in over a year. As a result, Material for MkDocs itself has entered maintenance mode, and the team has [announced Zensical](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) as its successor - a next-generation static site generator that consolidates static site generation, theming, and customization into a single coherent stack, free of the MkDocs dependency.
+`sommerfeldio/mkdocs` is built on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material), which in turn depends on **MkDocs**. MkDocs has been unmaintained since August 2024, with no releases in over a year. As a result, Material for MkDocs itself has entered maintenance mode, and the team has [announced Zensical](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) as its successor - a next-generation static site generator that consolidates static site generation, theming, and customization into a single coherent stack, free of the MkDocs dependency.
 
 ### Recommended migration: `sommerfeldio/zensical`
 

--- a/components/zensical/Dockerfile
+++ b/components/zensical/Dockerfile
@@ -1,0 +1,2 @@
+FROM zensical/zensical:0.0.57
+LABEL maintainer="sebastian@sommerfeld.io"

--- a/components/zensical/README.md
+++ b/components/zensical/README.md
@@ -1,0 +1,110 @@
+# sommerfeldio/zensical
+
+This image is used to build documentation sites using [Zensical](https://zensical.org), the Rust-based successor to MkDocs and Material for MkDocs. It is intended as the long-term replacement for [`sommerfeldio/mkdocs`](https://sommerfeld-io.github.io/container-images/container-images/mkdocs), which is now deprecated.
+
+- [sommerfeldio/zensical](https://hub.docker.com/r/sommerfeldio/zensical) on Docker Hub
+- [Dockerfile source code](https://github.com/sommerfeld-io/container-images/tree/main/components/zensical) on GitHub
+- [How to Contribute](https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md)
+- Visit [the projects documentation page](https://sommerfeld-io.github.io/container-images) for a list of all available container images.
+
+## Software Tags and Versioning
+
+Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
+
+### Software Bill of Materials (SBOM)
+
+A Software Bill of Materials (SBOM) in SPDX format is generated for this image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest`, and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/zensical:latest` or
+- `docker buildx imagetools inspect sommerfeldio/zensical:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+
+## About Zensical
+
+[Material for MkDocs](https://squidfunk.github.io/mkdocs-material) is built on top of MkDocs, which has been unmaintained since August 2024. Rather than fork MkDocs, the Material for MkDocs team [announced Zensical](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) - a ground-up, Rust-based rewrite that consolidates static site generation, theming, and customization into one coherent stack, free of the MkDocs dependency.
+
+- Zensical website: <https://zensical.org>
+- Zensical compatibility overview: <https://zensical.org/compatibility>
+- Zensical documentation: <https://zensical.org/docs>
+
+## Usage
+
+This image supports two modes, mirroring `sommerfeldio/mkdocs`. The `build` command builds the documentation site and then the container terminates. The `serve` command starts a development preview server. Unlike `sommerfeldio/mkdocs`, `zensical serve` binds to `localhost:8000` by default; this image's default command already passes `--dev-addr 0.0.0.0:8000` so port-mapping from Docker works out of the box.
+
+The development server is not recommended for production use. For production use, the `build` command should be used to generate the static site, which can then be served by a web server like [nginx](https://hub.docker.com/_/nginx) or [Apache httpd](https://hub.docker.com/_/httpd).
+
+### Native config, using `zensical.toml`
+
+```yaml
+services:
+
+  docs-build:
+    container_name: docs-build
+    image: &docs-image sommerfeldio/zensical:latest
+    volumes: &volumes
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+      - .:/workspaces/your-project
+    working_dir: &default-workdir /workspaces/your-project
+    command: build
+
+  docs-dev-server:
+    container_name: docs-dev-server
+    image: *docs-image
+    volumes: *volumes
+    working_dir: *default-workdir
+    ports:
+      - 3080:8000
+```
+
+If your project has only `zensical.toml` (no `mkdocs.yml`), Zensical picks it up automatically and no extra flag is needed.
+
+### Compatibility layer, using `mkdocs.yml`
+
+**Precedence:** if both `mkdocs.yml` and `zensical.toml` exist in the same directory, `zensical.toml` wins automatically with no flag needed. To force a specific file regardless of what else is present, pass `-f`/`--config-file` explicitly, e.g. `command: build -f mkdocs.yml`.
+
+For general getting-started information, see the official [Zensical "Get started" guide](https://zensical.org/docs/get-started/).
+
+## Migrating from `sommerfeldio/mkdocs`
+
+Zensical's native configuration format is `zensical.toml`. Going forward, that is the normal way to configure a site built with this image. Zensical also natively reads `mkdocs.yml` and reproduces the same HTML output, so an `mkdocs.yml`-based project keeps working through a compatibility layer while you migrate on your own schedule. There are two supported paths.
+
+### Path 1: Native `zensical.toml` configuration (recommended)
+
+`zensical.toml` mirrors `mkdocs.yml` structurally but uses TOML and nests settings under `[project]`:
+
+```toml
+[project]
+site_name = "My site"
+docs_dir = "docs"
+site_dir = "site"
+
+nav = [
+  "index.md",
+  { "About" = "about.md" },
+]
+
+[project.theme]
+font = { text = "Work Sans" }
+```
+
+This project's own documentation is translated this way as a worked example - see [`zensical.toml`](https://github.com/sommerfeld-io/container-images/blob/main/zensical.toml) at the root of this repository.
+
+### Path 2: `mkdocs.yml` compatibility layer (drop-in from `sommerfeldio/mkdocs`)
+
+The fastest way to move off `sommerfeldio/mkdocs`: change nothing except the image you run.
+
+- Keep your existing `mkdocs.yml`, Markdown files, template overrides, and CSS/JavaScript untouched.
+- Swap the image tag from `sommerfeldio/mkdocs` to `sommerfeldio/zensical` in your `docker-compose.yml` (or wherever you reference the image).
+- Rebuild. Zensical maps each plugin declared in `mkdocs.yml` to an equivalent Zensical module automatically.
+
+## Known limitations
+
+- **No official Kroki support (for now).** The [`mkdocs-kroki-plugin`](https://pypi.org/project/mkdocs-kroki-plugin) is not one of Zensical's [officially supported plugins](https://zensical.org/compatibility/plugins). Fenced diagram blocks (for example ` ```kroki-plantuml `) render as plain code blocks showing the raw diagram markup, not as an image. This is a known, accepted gap for the initial version of this image, tracked for a future update once Zensical's third-party module API is public.
+
+## License
+
+This container image is inheriting the [MIT License from the GitHub repository](https://sommerfeld-io.github.io/container-images/license).
+
+The license from this GitHub repository is compatible with the [license from the zensical/zensical project](https://github.com/zensical/zensical/blob/master/LICENSE.md) (which is MIT as well).

--- a/components/zensical/README.md
+++ b/components/zensical/README.md
@@ -30,6 +30,8 @@ The same SBOM is also attached as a downloadable asset on each [GitHub release](
 
 ## Usage
 
+This image can be used as a drop-in replacement for `sommerfeldio/mkdocs` and automatically reads your existing `mkdocs.yml` configuration. However, going forward, it is recommended to migrate to `zensical.toml` as the native configuration format.
+
 This image supports two modes, mirroring `sommerfeldio/mkdocs`. The `build` command builds the documentation site and then the container terminates. The `serve` command starts a development preview server. Unlike `sommerfeldio/mkdocs`, `zensical serve` binds to `localhost:8000` by default; this image's default command already passes `--dev-addr 0.0.0.0:8000` so port-mapping from Docker works out of the box.
 
 The development server is not recommended for production use. For production use, the `build` command should be used to generate the static site, which can then be served by a web server like [nginx](https://hub.docker.com/_/nginx) or [Apache httpd](https://hub.docker.com/_/httpd).
@@ -55,49 +57,16 @@ services:
     volumes: *volumes
     working_dir: *default-workdir
     ports:
-      - 3080:8000
+      - 8000:8000
 ```
-
-If your project has only `zensical.toml` (no `mkdocs.yml`), Zensical picks it up automatically and no extra flag is needed.
 
 ### Compatibility layer, using `mkdocs.yml`
 
-**Precedence:** if both `mkdocs.yml` and `zensical.toml` exist in the same directory, `zensical.toml` wins automatically with no flag needed. To force a specific file regardless of what else is present, pass `-f`/`--config-file` explicitly, e.g. `command: build -f mkdocs.yml`.
-
-For general getting-started information, see the official [Zensical "Get started" guide](https://zensical.org/docs/get-started/).
-
-## Migrating from `sommerfeldio/mkdocs`
-
 Zensical's native configuration format is `zensical.toml`. Going forward, that is the normal way to configure a site built with this image. Zensical also natively reads `mkdocs.yml` and reproduces the same HTML output, so an `mkdocs.yml`-based project keeps working through a compatibility layer while you migrate on your own schedule. There are two supported paths.
 
-### Path 1: Native `zensical.toml` configuration (recommended)
+If both `mkdocs.yml` and `zensical.toml` exist in the same directory, `zensical.toml` wins automatically with no flag needed. To force a specific file regardless of what else is present, pass `-f` / `--config-file` explicitly, e.g. `command: build -f mkdocs.yml`.
 
-`zensical.toml` mirrors `mkdocs.yml` structurally but uses TOML and nests settings under `[project]`:
-
-```toml
-[project]
-site_name = "My site"
-docs_dir = "docs"
-site_dir = "site"
-
-nav = [
-  "index.md",
-  { "About" = "about.md" },
-]
-
-[project.theme]
-font = { text = "Work Sans" }
-```
-
-This project's own documentation is translated this way as a worked example - see [`zensical.toml`](https://github.com/sommerfeld-io/container-images/blob/main/zensical.toml) at the root of this repository.
-
-### Path 2: `mkdocs.yml` compatibility layer (drop-in from `sommerfeldio/mkdocs`)
-
-The fastest way to move off `sommerfeldio/mkdocs`: change nothing except the image you run.
-
-- Keep your existing `mkdocs.yml`, Markdown files, template overrides, and CSS/JavaScript untouched.
-- Swap the image tag from `sommerfeldio/mkdocs` to `sommerfeldio/zensical` in your `docker-compose.yml` (or wherever you reference the image).
-- Rebuild. Zensical maps each plugin declared in `mkdocs.yml` to an equivalent Zensical module automatically.
+For general getting-started information, see the official [Zensical "Get started" guide](https://zensical.org/docs/get-started/).
 
 ## Known limitations
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -182,14 +182,14 @@ services:
     image: &zensical-docs-image sommerfeldio/zensical:latest
     volumes: *volumes
     working_dir: *default-workdir
-    command: build -f zensical.toml
+    command: build
     tty: *tty
 
   zensical-docs-dev-server:
     image: *zensical-docs-image
     volumes: *volumes
     working_dir: *default-workdir
-    command: serve -f zensical.toml --dev-addr 0.0.0.0:8000
+    command: serve --dev-addr 0.0.0.0:8000
     ports:
-      - 3081:8000
+      - 3080:8000
     tty: *tty

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,14 +178,14 @@ services:
 
   # ---------------------------------------------------------------------------
 
-  zensical-docs-build:
+  docs-build:
     image: &zensical-docs-image sommerfeldio/zensical:latest
     volumes: *volumes
     working_dir: *default-workdir
     command: build
     tty: *tty
 
-  zensical-docs-dev-server:
+  docs-dev-server:
     image: *zensical-docs-image
     volumes: *volumes
     working_dir: *default-workdir

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,21 +69,6 @@ services:
     working_dir: *default-workdir
     tty: *tty
 
-  docs-build:
-    image: &docs-image sommerfeldio/mkdocs:latest
-    volumes: *volumes
-    working_dir: *default-workdir
-    command: build
-    tty: *tty
-
-  docs-dev-server:
-    image: *docs-image
-    volumes: *volumes
-    working_dir: *default-workdir
-    ports:
-      - 3080:8000
-    tty: *tty
-
   devcontainer-lint-dockerfile:
     image: &lint-dockerfile-image hadolint/hadolint:latest
     volumes: *volumes
@@ -173,4 +158,52 @@ services:
       target: pdf
     volumes: *volumes
     working_dir: *default-workdir
+    tty: *tty
+
+  zensical-lint-dockerfile:
+    image: *lint-dockerfile-image
+    volumes: *volumes
+    working_dir: *default-workdir
+    entrypoint: hadolint components/zensical/Dockerfile
+    tty: *tty
+
+  zensical:
+    image: local/zensical:${DEV_TAG}
+    build:
+      context: components/zensical
+      dockerfile: Dockerfile
+    volumes: *volumes
+    working_dir: *default-workdir
+    tty: *tty
+
+  # ---------------------------------------------------------------------------
+
+  mkdocs-docs-build:
+    image: &docs-image sommerfeldio/mkdocs:latest
+    volumes: *volumes
+    working_dir: *default-workdir
+    command: build
+    tty: *tty
+
+  mkdocs-docs-dev-server:
+    image: *docs-image
+    volumes: *volumes
+    working_dir: *default-workdir
+    ports:
+      - 3080:8000
+    tty: *tty
+  zensical-docs-build:
+    image: &zensical-docs-image local/zensical:${DEV_TAG}
+    volumes: *volumes
+    working_dir: *default-workdir
+    command: build -f zensical.toml
+    tty: *tty
+
+  zensical-docs-dev-server:
+    image: *zensical-docs-image
+    volumes: *volumes
+    working_dir: *default-workdir
+    command: serve -f zensical.toml --dev-addr 0.0.0.0:8000
+    ports:
+      - 3081:8000
     tty: *tty

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,22 +178,8 @@ services:
 
   # ---------------------------------------------------------------------------
 
-  mkdocs-docs-build:
-    image: &docs-image sommerfeldio/mkdocs:latest
-    volumes: *volumes
-    working_dir: *default-workdir
-    command: build
-    tty: *tty
-
-  mkdocs-docs-dev-server:
-    image: *docs-image
-    volumes: *volumes
-    working_dir: *default-workdir
-    ports:
-      - 3080:8000
-    tty: *tty
   zensical-docs-build:
-    image: &zensical-docs-image local/zensical:${DEV_TAG}
+    image: &zensical-docs-image sommerfeldio/zensical:latest
     volumes: *volumes
     working_dir: *default-workdir
     command: build -f zensical.toml

--- a/docs/container-images/mkdocs.md
+++ b/docs/container-images/mkdocs.md
@@ -2,20 +2,53 @@
 
 This image is used to build the documentation using the `mkdocs` toolchain and is based on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material).
 
-This image extends the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) image with the [mkdocs-kroki-plugin](https://pypi.org/project/mkdocs-kroki-plugin) to allow rendering diagrams and charts using [Kroki.io](https://kroki.io). A dedicated Dockerfile is needed because the base image does not provide all necessary plugins and tools.
+![Deprecated](https://raw.githubusercontent.com/sommerfeld-io/container-images/refs/heads/main/.assets/deprecated.png)
 
 - [sommerfeldio/mkdocs](https://hub.docker.com/r/sommerfeldio/mkdocs) on Docker Hub
 - [Dockerfile source code](https://github.com/sommerfeld-io/container-images/tree/main/components/mkdocs) on GitHub
 - [How to Contribute](https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md)
 - Visit [the projects documentation page](https://sommerfeld-io.github.io/container-images) for a list of all available container images.
 
+## DEPRECATION NOTICE: `sommerfeldio/mkdocs` is deprecated as of version `0.28.0`
+
+Starting with `0.28.0`, the `sommerfeldio/mkdocs` container image will **no longer be maintained**. This means:
+
+- No new features
+- No bug fixes
+- No security updates
+- No dependency upgrades
+
+The image will remain available on GitHub, but it is stale and should not be relied upon for anything going forward. `0.28.0` is the last version available on Docker Hub.
+
+`sommerfeldio/mkdocs` is built on [Material for MkDocs](https://squidfunk.github.io/mkdocs-material), which in turn depends on **MkDocs**. MkDocs has been unmaintained since August 2024, with no releases in over a year. As a result, Material for MkDocs itself has entered maintenance mode, and the team has [announced Zensical](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) as its successor - a next-generation static site generator that consolidates static site generation, theming, and customization into a single coherent stack, free of the MkDocs dependency.
+
+### Recommended migration: `sommerfeldio/zensical`
+
+Switch to `sommerfeldio/zensical` as a drop-in replacement. Because Zensical guarantees compatibility with Material for MkDocs, migrating away from `sommerfeldio/mkdocs` should require little to no change to your documentation sources.
+
+- Reads your existing `mkdocs.yml` natively, so you can build your current project with minimal changes.
+- Leaves your Markdown files, template overrides, and CSS/JavaScript extensions untouched (the generated HTML is unchanged and content is still processed via Python Markdown).
+- Ships as fully Open Source (MIT-licensed).
+
+Review the [Zensical compatibility page](https://zensical.org/compatibility/) before migrating if you rely on specific plugins.
+
+### Learn more
+
+- Zensical announcement: <https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/>
+- Zensical website: <https://zensical.org/>
+- Zensical compatibility: <https://zensical.org/compatibility/>
+
+## About the latest stable release which is `sommerfeldio/mkdocs:0.28.0`
+
+This image extends the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) image with the [mkdocs-kroki-plugin](https://pypi.org/project/mkdocs-kroki-plugin) to allow rendering diagrams and charts using [Kroki.io](https://kroki.io). A dedicated Dockerfile is needed because the base image does not provide all necessary plugins and tools.
+
 The image focuses on generating the documentation site (e.g. from a pipeline). It is not intended to be used as a live webserver for production.
 
-## Software Tags and Versioning
+### Software Tags and Versioning
 
 Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
 
-### Software Bill of Materials (SBOM)
+#### Software Bill of Materials (SBOM)
 
 Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format is generated for every image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest` and versioned tags. Retrieve it with
 
@@ -24,7 +57,7 @@ Starting with version 0.25.2, a Software Bill of Materials (SBOM) in SPDX format
 
 The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
 
-## Usage
+### Usage
 
 This image supports two modes. The `build` command is used to build the documentation site based on your Markdown docs. The container terminates after the build is complete. Additionally the image offers a development server to preview the documentation site. Both features originate in the [squidfunk/mkdocs-material](https://hub.docker.com/r/squidfunk/mkdocs-material) base image.
 

--- a/docs/container-images/zensical.md
+++ b/docs/container-images/zensical.md
@@ -1,0 +1,110 @@
+# sommerfeldio/zensical
+
+This image is used to build documentation sites using [Zensical](https://zensical.org), the Rust-based successor to MkDocs and Material for MkDocs. It is intended as the long-term replacement for [`sommerfeldio/mkdocs`](https://sommerfeld-io.github.io/container-images/container-images/mkdocs), which is now deprecated.
+
+- [sommerfeldio/zensical](https://hub.docker.com/r/sommerfeldio/zensical) on Docker Hub
+- [Dockerfile source code](https://github.com/sommerfeld-io/container-images/tree/main/components/zensical) on GitHub
+- [How to Contribute](https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md)
+- Visit [the projects documentation page](https://sommerfeld-io.github.io/container-images) for a list of all available container images.
+
+## Software Tags and Versioning
+
+Learn about our tagging policy and the difference between rolling tags and immutable tags [on our documentation page⁠](https://github.com/sommerfeld-io/.github/blob/main/docs/tags-and-versions.md).
+
+### Software Bill of Materials (SBOM)
+
+A Software Bill of Materials (SBOM) in SPDX format is generated for this image at build time and attached directly to the image in Docker Hub as an OCI attestation, available for the `edge`, `latest`, and versioned tags. Retrieve it with
+
+- `docker scout sbom sommerfeldio/zensical:latest` or
+- `docker buildx imagetools inspect sommerfeldio/zensical:latest --format "{{ json .SBOM }}"`.
+
+The same SBOM is also attached as a downloadable asset on each [GitHub release](https://github.com/sommerfeld-io/container-images/releases).
+
+## About Zensical
+
+[Material for MkDocs](https://squidfunk.github.io/mkdocs-material) is built on top of MkDocs, which has been unmaintained since August 2024. Rather than fork MkDocs, the Material for MkDocs team [announced Zensical](https://squidfunk.github.io/mkdocs-material/blog/2025/11/05/zensical/) - a ground-up, Rust-based rewrite that consolidates static site generation, theming, and customization into one coherent stack, free of the MkDocs dependency.
+
+- Zensical website: <https://zensical.org>
+- Zensical compatibility overview: <https://zensical.org/compatibility>
+- Zensical documentation: <https://zensical.org/docs>
+
+## Usage
+
+This image supports two modes, mirroring `sommerfeldio/mkdocs`. The `build` command builds the documentation site and then the container terminates. The `serve` command starts a development preview server. Unlike `sommerfeldio/mkdocs`, `zensical serve` binds to `localhost:8000` by default; this image's default command already passes `--dev-addr 0.0.0.0:8000` so port-mapping from Docker works out of the box.
+
+The development server is not recommended for production use. For production use, the `build` command should be used to generate the static site, which can then be served by a web server like [nginx](https://hub.docker.com/_/nginx) or [Apache httpd](https://hub.docker.com/_/httpd).
+
+### Native config, using `zensical.toml`
+
+```yaml
+services:
+
+  docs-build:
+    container_name: docs-build
+    image: &docs-image sommerfeldio/zensical:latest
+    volumes: &volumes
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+      - .:/workspaces/your-project
+    working_dir: &default-workdir /workspaces/your-project
+    command: build
+
+  docs-dev-server:
+    container_name: docs-dev-server
+    image: *docs-image
+    volumes: *volumes
+    working_dir: *default-workdir
+    ports:
+      - 3080:8000
+```
+
+If your project has only `zensical.toml` (no `mkdocs.yml`), Zensical picks it up automatically and no extra flag is needed.
+
+### Compatibility layer, using `mkdocs.yml`
+
+**Precedence:** if both `mkdocs.yml` and `zensical.toml` exist in the same directory, `zensical.toml` wins automatically with no flag needed. To force a specific file regardless of what else is present, pass `-f`/`--config-file` explicitly, e.g. `command: build -f mkdocs.yml`.
+
+For general getting-started information, see the official [Zensical "Get started" guide](https://zensical.org/docs/get-started/).
+
+## Migrating from `sommerfeldio/mkdocs`
+
+Zensical's native configuration format is `zensical.toml`. Going forward, that is the normal way to configure a site built with this image. Zensical also natively reads `mkdocs.yml` and reproduces the same HTML output, so an `mkdocs.yml`-based project keeps working through a compatibility layer while you migrate on your own schedule. There are two supported paths.
+
+### Path 1: Native `zensical.toml` configuration (recommended)
+
+`zensical.toml` mirrors `mkdocs.yml` structurally but uses TOML and nests settings under `[project]`:
+
+```toml
+[project]
+site_name = "My site"
+docs_dir = "docs"
+site_dir = "site"
+
+nav = [
+  "index.md",
+  { "About" = "about.md" },
+]
+
+[project.theme]
+font = { text = "Work Sans" }
+```
+
+This project's own documentation is translated this way as a worked example - see [`zensical.toml`](https://github.com/sommerfeld-io/container-images/blob/main/zensical.toml) at the root of this repository.
+
+### Path 2: `mkdocs.yml` compatibility layer (drop-in from `sommerfeldio/mkdocs`)
+
+The fastest way to move off `sommerfeldio/mkdocs`: change nothing except the image you run.
+
+- Keep your existing `mkdocs.yml`, Markdown files, template overrides, and CSS/JavaScript untouched.
+- Swap the image tag from `sommerfeldio/mkdocs` to `sommerfeldio/zensical` in your `docker-compose.yml` (or wherever you reference the image).
+- Rebuild. Zensical maps each plugin declared in `mkdocs.yml` to an equivalent Zensical module automatically.
+
+## Known limitations
+
+- **No official Kroki support (for now).** The [`mkdocs-kroki-plugin`](https://pypi.org/project/mkdocs-kroki-plugin) is not one of Zensical's [officially supported plugins](https://zensical.org/compatibility/plugins). Fenced diagram blocks (for example ` ```kroki-plantuml `) render as plain code blocks showing the raw diagram markup, not as an image. This is a known, accepted gap for the initial version of this image, tracked for a future update once Zensical's third-party module API is public.
+
+## License
+
+This container image is inheriting the [MIT License from the GitHub repository](https://sommerfeld-io.github.io/container-images/license).
+
+The license from this GitHub repository is compatible with the [license from the zensical/zensical project](https://github.com/zensical/zensical/blob/master/LICENSE.md) (which is MIT as well).

--- a/docs/container-images/zensical.md
+++ b/docs/container-images/zensical.md
@@ -30,6 +30,8 @@ The same SBOM is also attached as a downloadable asset on each [GitHub release](
 
 ## Usage
 
+This image can be used as a drop-in replacement for `sommerfeldio/mkdocs` and automatically reads your existing `mkdocs.yml` configuration. However, going forward, it is recommended to migrate to `zensical.toml` as the native configuration format.
+
 This image supports two modes, mirroring `sommerfeldio/mkdocs`. The `build` command builds the documentation site and then the container terminates. The `serve` command starts a development preview server. Unlike `sommerfeldio/mkdocs`, `zensical serve` binds to `localhost:8000` by default; this image's default command already passes `--dev-addr 0.0.0.0:8000` so port-mapping from Docker works out of the box.
 
 The development server is not recommended for production use. For production use, the `build` command should be used to generate the static site, which can then be served by a web server like [nginx](https://hub.docker.com/_/nginx) or [Apache httpd](https://hub.docker.com/_/httpd).
@@ -55,49 +57,16 @@ services:
     volumes: *volumes
     working_dir: *default-workdir
     ports:
-      - 3080:8000
+      - 8000:8000
 ```
-
-If your project has only `zensical.toml` (no `mkdocs.yml`), Zensical picks it up automatically and no extra flag is needed.
 
 ### Compatibility layer, using `mkdocs.yml`
 
-**Precedence:** if both `mkdocs.yml` and `zensical.toml` exist in the same directory, `zensical.toml` wins automatically with no flag needed. To force a specific file regardless of what else is present, pass `-f`/`--config-file` explicitly, e.g. `command: build -f mkdocs.yml`.
-
-For general getting-started information, see the official [Zensical "Get started" guide](https://zensical.org/docs/get-started/).
-
-## Migrating from `sommerfeldio/mkdocs`
-
 Zensical's native configuration format is `zensical.toml`. Going forward, that is the normal way to configure a site built with this image. Zensical also natively reads `mkdocs.yml` and reproduces the same HTML output, so an `mkdocs.yml`-based project keeps working through a compatibility layer while you migrate on your own schedule. There are two supported paths.
 
-### Path 1: Native `zensical.toml` configuration (recommended)
+If both `mkdocs.yml` and `zensical.toml` exist in the same directory, `zensical.toml` wins automatically with no flag needed. To force a specific file regardless of what else is present, pass `-f` / `--config-file` explicitly, e.g. `command: build -f mkdocs.yml`.
 
-`zensical.toml` mirrors `mkdocs.yml` structurally but uses TOML and nests settings under `[project]`:
-
-```toml
-[project]
-site_name = "My site"
-docs_dir = "docs"
-site_dir = "site"
-
-nav = [
-  "index.md",
-  { "About" = "about.md" },
-]
-
-[project.theme]
-font = { text = "Work Sans" }
-```
-
-This project's own documentation is translated this way as a worked example - see [`zensical.toml`](https://github.com/sommerfeld-io/container-images/blob/main/zensical.toml) at the root of this repository.
-
-### Path 2: `mkdocs.yml` compatibility layer (drop-in from `sommerfeldio/mkdocs`)
-
-The fastest way to move off `sommerfeldio/mkdocs`: change nothing except the image you run.
-
-- Keep your existing `mkdocs.yml`, Markdown files, template overrides, and CSS/JavaScript untouched.
-- Swap the image tag from `sommerfeldio/mkdocs` to `sommerfeldio/zensical` in your `docker-compose.yml` (or wherever you reference the image).
-- Rebuild. Zensical maps each plugin declared in `mkdocs.yml` to an equivalent Zensical module automatically.
+For general getting-started information, see the official [Zensical "Get started" guide](https://zensical.org/docs/get-started/).
 
 ## Known limitations
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -73,12 +73,14 @@ nav:
       - container-images/ftp-client.md
       - container-images/mkdocs.md
       - container-images/revealjs.md
+      - container-images/zensical.md
   - license.md
-  - Releases on GitHub ⧉: https://github.com/sommerfeld-io/container-images/releases
-  - Architecture Decision Records on GitHub ⧉: https://github.com/sommerfeld-io/container-images/issues?q=is%3Aissue+label%3AADR
-  - Development Guide ⧉: https://github.com/sommerfeld-io/.github/blob/main/docs/development-guide.md
-  - Code Guideline - Pipelines ⧉: https://github.com/sommerfeld-io/.github/blob/main/docs/code-guideline-pipelines.md
-  - How to Contribute ⧉: https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md
-  - Code of Conduct ⧉: https://github.com/sommerfeld-io/.github/blob/main/CODE_OF_CONDUCT.md
-  - Security Policy ⧉: https://github.com/sommerfeld-io/.github/blob/main/SECURITY.md
-  - Terms of Use ⧉: https://github.com/sommerfeld-io/.github/blob/main/docs/terms.md
+  - On Github.com  ⧉:
+      - Releases ⧉: https://github.com/sommerfeld-io/container-images/releases
+      - Architecture Decision Records ⧉: https://github.com/sommerfeld-io/container-images/issues?q=is%3Aissue+label%3AADR
+      - Development Guide ⧉: https://github.com/sommerfeld-io/.github/blob/main/docs/development-guide.md
+      - Code Guideline - Pipelines ⧉: https://github.com/sommerfeld-io/.github/blob/main/docs/code-guideline-pipelines.md
+      - How to Contribute ⧉: https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md
+      - Code of Conduct ⧉: https://github.com/sommerfeld-io/.github/blob/main/CODE_OF_CONDUCT.md
+      - Security Policy ⧉: https://github.com/sommerfeld-io/.github/blob/main/SECURITY.md
+      - Terms of Use ⧉: https://github.com/sommerfeld-io/.github/blob/main/docs/terms.md

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -106,7 +106,6 @@ tasks:
     desc: Serve this repo's docs with zensical, native config (zensical.toml)
     cmds:
       - task: docs:generate
-      - task: build:zensical
       - docker compose up zensical-docs-build
       - docker compose up zensical-docs-dev-server
 

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -9,7 +9,6 @@ vars:
 includes:
   cleanup: .task/cleanup/taskfile.yml
   common: .task/common/taskfile.yml
-  copilot: .github/skills/taskfile.yml
   revealjs: components/revealjs/taskfile.yml
 
 tasks:

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -102,12 +102,12 @@ tasks:
         task: common:copy
         vars: { SRC: "components/{{ .ITEM }}/README.md", DEST: "docs/container-images/{{ .ITEM }}.md" }
 
-  docs:zensical:run:
+  docs:run:
     desc: Serve this repo's docs with zensical, native config (zensical.toml)
     cmds:
       - task: docs:generate
-      - docker compose up zensical-docs-build
-      - docker compose up zensical-docs-dev-server
+      - docker compose up docs-build
+      - docker compose up docs-dev-server
 
   # ===============================================================================================
 

--- a/taskfile.yml
+++ b/taskfile.yml
@@ -59,7 +59,7 @@ tasks:
       - task: symlinks
       - for: ['yaml', 'workflows', 'filenames', 'folders', 'markdown-links']
         cmd: docker compose up lint-{{ .ITEM }} --exit-code-from lint-{{ .ITEM }}
-      - for: &images ['devcontainer', 'folderslint', 'ftp-client', 'mkdocs', 'revealjs']
+      - for: &images ['devcontainer', 'folderslint', 'ftp-client', 'mkdocs', 'revealjs', 'zensical']
         task: lint:dockerfile
         vars: { IMAGE: '{{ .ITEM }}' }
 
@@ -102,11 +102,13 @@ tasks:
         task: common:copy
         vars: { SRC: "components/{{ .ITEM }}/README.md", DEST: "docs/container-images/{{ .ITEM }}.md" }
 
-  docs:run:
-    desc: Run the documentation server
+  docs:zensical:run:
+    desc: Serve this repo's docs with zensical, native config (zensical.toml)
     cmds:
       - task: docs:generate
-      - docker compose up docs-dev-server
+      - task: build:zensical
+      - docker compose up zensical-docs-build
+      - docker compose up zensical-docs-dev-server
 
   # ===============================================================================================
 

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,7 +1,7 @@
 [project]
-site_name = "Container Images ZZZ"
+site_name = "Container Images"
 docs_dir = "docs"
-site_dir = "target/docs/site-native"
+site_dir = "target/docs/site"
 copyright = "Copyright &copy; 2024 Sommerfeld.io"
 
 nav = [

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,49 @@
+[project]
+site_name = "Container Images ZZZ"
+docs_dir = "docs"
+site_dir = "target/docs/site-native"
+copyright = "Copyright &copy; 2024 Sommerfeld.io"
+
+nav = [
+  "index.md",
+  { "Container Images" = [
+    "container-images/devcontainer.md",
+    "container-images/folderslint.md",
+    "container-images/ftp-client.md",
+    "container-images/mkdocs.md",
+    "container-images/revealjs.md",
+    "container-images/zensical.md",
+  ] },
+  "license.md",
+  { "On Github.com" = [
+    { "Releases" = "https://github.com/sommerfeld-io/container-images/releases" },
+    { "Architecture Decision Records" = "https://github.com/sommerfeld-io/container-images/issues?q=is%3Aissue+label%3AADR" },
+    { "Development Guide" = "https://github.com/sommerfeld-io/.github/blob/main/docs/development-guide.md" },
+    { "Code Guideline - Pipelines" = "https://github.com/sommerfeld-io/.github/blob/main/docs/code-guideline-pipelines.md" },
+    { "How to Contribute" = "https://github.com/sommerfeld-io/.github/blob/main/CONTRIBUTING.md" },
+    { "Code of Conduct" = "https://github.com/sommerfeld-io/.github/blob/main/CODE_OF_CONDUCT.md" },
+    { "Security Policy" = "https://github.com/sommerfeld-io/.github/blob/main/SECURITY.md" },
+    { "Terms of Use" = "https://github.com/sommerfeld-io/.github/blob/main/docs/terms.md" },
+  ] },
+]
+
+[project.theme]
+font = { text = "Work Sans" }
+features = [
+  "content.code.copy",
+  "content.tabs.link",
+  "navigation.footer",
+  "navigation.expand",
+  "navigation.tracking",
+]
+
+[project.theme.palette]
+scheme = "slate"
+primary = "blue grey"
+accent = "deep orange"
+
+[project.extra]
+social = [
+  { icon = "fontawesome/brands/github", link = "https://github.com/sommerfeld-io/container-images" },
+  { icon = "fontawesome/brands/docker", link = "https://hub.docker.com/u/sommerfeldio" },
+]


### PR DESCRIPTION
MkDocs has been unmaintained upstream for over a year, and the Material for MkDocs team responded by building Zensical, a Rust-based successor with built-in `mkdocs.yml` compatibility. This PR introduces `sommerfeldio/zensical` as a new container image, switches this repository's own GitHub Pages docs build over to it via a native `zensical.toml` config, and keeps `sommerfeldio/mkdocs` fully intact (built, linted, tested, and published) so downstream consumers can migrate at their own pace.

### Changes

- Adds `components/zensical` (a Dockerfile built on the official `zensical/zensical` image, and a README covering both a native-`zensical.toml` migration path and a `mkdocs.yml` compatibility layer, plus documented known limitations such as no Kroki plugin support yet).
- Wires `zensical` into `taskfile.yml`, `docker-compose.yml`, and the CI matrices in `pipeline.yml`/`release.yml`, alongside the unmodified `mkdocs` entries.
- Adds a root `zensical.toml` that mirrors this repository's `mkdocs.yml` (navigation, theme palette and dark mode, fonts, copyright, social links) and switches the release pipeline's GitHub Pages build/deploy to use it.
- Reclaims the `docs-build` / `docs-dev-server` / `docs:run` names for the new zensical-driven docs pipeline, now that it is the one producing the published site.
- Removes the unused `.github/skills` git submodule and its references from `.gitmodules`, `.ls-lint.yml`, `.folderslintrc`, and `taskfile.yml`.
- Adds a temporary, clearly-commented `.lychee.toml` exclusion for the new component's GitHub and Docker Hub links, which 404 until this branch is merged and the image's first Docker Hub publish completes.

### Benefits

- Removes the project's dependency on the unmaintained MkDocs toolchain for building its own documentation site.
- Gives downstream users of `sommerfeldio/mkdocs` a documented, low-risk path to `sommerfeldio/zensical`, with an explicit compatibility layer so nothing breaks immediately.
- Keeps the migration reversible: `mkdocs` stays fully built, tested, and published in every pipeline until a separate, deliberate follow-up removes it.
- Establishes a tested, working native `zensical.toml` configuration that can serve as a template for migrating other projects off MkDocs.
